### PR TITLE
Clear local storage of chatkit-users without a token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,11 @@ class View extends React.Component {
 // Authentication
 // --------------------------------------
 
+window.localStorage.getItem('chatkit-user') &&
+  !JSON.parse(window.localStorage.getItem('chatkit-user')).id &&
+  !JSON.parse(window.localStorage.getItem('chatkit-user')).token &&
+  window.localStorage.clear()
+
 const params = new URLSearchParams(window.location.search.slice(1))
 const authCode = params.get('code')
 const existingUser = window.localStorage.getItem('chatkit-user')


### PR DESCRIPTION
I was seeing errors when on the production namespace.. I did a debug and safari was looking for an old chatkit user (they used to just be usernames stored) that had no token.

Now we check if there is a user in localStorage then check if it has an `id` and a `token` property. If it does not, we clear storage and start the auth process from scratch.