### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - "9"
 
-script: npm run build
+script: CI=false yarn build
 
 deploy:
   local_dir: build


### PR DESCRIPTION
Since we are using Yarn it think it should be `yarn build`.
`CI=false` to not consider warnings as error and fail build.(just for now)