### PR TITLE
Attachment format file

### DIFF
--- a/src/components/FileInput/index.js
+++ b/src/components/FileInput/index.js
@@ -1,14 +1,6 @@
 import React from 'react'
 import style from './index.module.css'
 
-function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    var r = (Math.random() * 16) | 0,
-      v = c === 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
-}
-
 export const FileInput = ({ state: { user, message, room } }) =>
   room.id ? (
     <button>
@@ -25,7 +17,7 @@ export const FileInput = ({ state: { user, message, room } }) =>
               text: message || file.name,
               roomId: room.id,
               attachment: {
-                name: uuidv4(),
+                name: file.name.replace(/[^A-Za-z0-9._-]/g, '--'),
                 file,
               },
             })

--- a/src/components/Message/index.js
+++ b/src/components/Message/index.js
@@ -25,6 +25,11 @@ class Attachment extends React.Component {
           ),
           video: <video controls={true} src={this.state.src} />,
           audio: <audio controls={true} src={this.state.src} />,
+          file: (
+            <a href={this.state.src} download>
+              Download File
+            </a>
+          ),
         }[this.props.type]
       : null
   }


### PR DESCRIPTION
Addresses #30 

## What changes

- Attachment file names used to be `uuid` to ensure server doesn't reject it as a bad path due to disallowed characters `[^A-Za-z0-9._-]`. This meant that when you downloaded attachments, the name and extension of the original upload was lost; which is not desirable. Now we replace disallowed characters with `--` at the point of upload.
- Display download links for file attachments of type `file`.