### PR TITLE
Adds desktop notification support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 client/static/index.js
 .DS_Store
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatkit-demo",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "homepage": "https://pusher.github.io/react-slack-clone",
   "dependencies": {
     "@pusher/chatkit": "^0.7.3",

--- a/src/index.js
+++ b/src/index.js
@@ -66,13 +66,12 @@ class View extends React.Component {
         )
     },
 
-    subscribeToRoom: room => {
+    subscribeToRoom: room =>
       !this.state.user.roomSubscriptions[room.id] &&
-        this.state.user.subscribeToRoom({
-          roomId: room.id,
-          hooks: { onNewMessage: this.actions.addMessage },
-        })
-    },
+      this.state.user.subscribeToRoom({
+        roomId: room.id,
+        hooks: { onNewMessage: this.actions.addMessage },
+      }),
 
     createRoom: options =>
       this.state.user.createRoom(options).then(this.actions.joinRoom),
@@ -197,7 +196,7 @@ class View extends React.Component {
   }
 
   componentDidMount() {
-    Notification.requestPermission()
+    'Notification' in window && Notification.requestPermission()
     existingUser
       ? ChatManager(this, JSON.parse(existingUser))
       : fetch('https://chatkit-demo-server.herokuapp.com/auth', {


### PR DESCRIPTION
Addresses https://github.com/pusher/react-slack-clone/issues/14. Thanks to @DevFlex for kicking this off! A notification is now shown like so:

<img width="391" alt="screen shot 2018-04-10 at 17 47 58" src="https://user-images.githubusercontent.com/1457604/38571072-6189093a-3ce7-11e8-86e8-0ce7fe4e73d1.png">

When the device supports Notifications and has allowed them, the window visibility is _hidden_ and the message received is not your own.

The notification will include the message senders name, avatar and the text from the message. If you click on the notification it will focus on the window that spawned the notification and switch to the room where the message resides.