### PR TITLE
Don't send empty space messages

### DIFF
--- a/src/components/CreateMessageForm/index.js
+++ b/src/components/CreateMessageForm/index.js
@@ -11,12 +11,18 @@ export const CreateMessageForm = ({
       className={style.component}
       onSubmit={e => {
         e.preventDefault()
-        const message = e.target[0].value
+
+        const message = e.target[0].value.trim()
+
+        if (message.length === 0) {
+          return
+        }
+
         e.target[0].value = ''
+
         message.startsWith('/')
           ? runCommand(message.slice(1))
-          : message.length > 0 &&
-            user.sendMessage({
+          : user.sendMessage({
               text: message,
               roomId: room.id,
             })


### PR DESCRIPTION
Addresses issue https://github.com/pusher/react-slack-clone/issues/71

1. Trim the user's input (cut out leading/trailing whitespace)
2. Bail if input is empty
3. Otherwise, continue existing logic

Thoughts @mike1136? Wondering if you imagined a similar implementation.