### PR TITLE
Update actions to not use object-path-immutable 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "homepage": "https://pusher.github.io/react-slack-clone",
   "dependencies": {
     "@pusher/chatkit-client": "^1.3.0",
-    "object-path-immutable": "^1.0.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-linkify": "^0.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { set, del } from 'object-path-immutable'
 import { version } from '../package.json'
 import './index.css'
 
@@ -122,7 +121,15 @@ class View extends React.Component {
       const roomId = payload.room.id
       const messageId = payload.id
       // Update local message cache with new message
-      this.setState(set(this.state, ['messages', roomId, messageId], payload))
+      this.setState(prevState => ({
+        messages: {
+          ...prevState.messages,
+          [roomId]: {
+            ...prevState.messages[roomId],
+            [messageId]: payload
+          }
+        }
+      }))
       // Update cursor if the message was read
       if (roomId === this.state.room.id) {
         const cursor = this.state.user.readCursor({ roomId }) || {}
@@ -158,10 +165,26 @@ class View extends React.Component {
     // --------------------------------------
 
     isTyping: (room, user) =>
-      this.setState(set(this.state, ['typing', room.id, user.id], true)),
+      this.setState(prevState => ({
+        typing: {
+          ...prevState.typing,
+          [room.id]: {
+            ...prevState.typing[room.id],
+            [user.id]: true
+          }
+        }
+      })),
 
     notTyping: (room, user) =>
-      this.setState(del(this.state, ['typing', room.id, user.id])),
+      this.setState(prevState => ({
+        typing: {
+          ...prevState.typing,
+          [room.id]: {
+            ...prevState.typing[room.id],
+            [user.id]: false
+          }
+        }
+      })),
 
     // --------------------------------------
     // Presence

--- a/yarn.lock
+++ b/yarn.lock
@@ -5874,10 +5874,6 @@ object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
-object-path-immutable@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object-path-immutable/-/object-path-immutable-1.0.1.tgz#3c424052be3c54ec82def03f1b11b0c6e085c7ff"
-
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"


### PR DESCRIPTION
I used this code as an example when creating an app however when we had a considerable number of users and messages in rooms we found that there was a huge lag in on subscription.

After a little bit of digging we found the `addMessage` function was taking approx 3000ms and that `set` from `object-path-immutable` seemed to be causing the problem which was used to update a deeply nested object in state.

<img width="776" alt="screen shot 2019-02-18 at 18 47 53" src="https://user-images.githubusercontent.com/25408167/52973489-37846a00-33b6-11e9-972c-0bb853a6f054.png">

I've rewritten `addMessage`, `isTyping` and `notTyping` without object-path-immutable. A quick look at `addMessage` in the performance dev tools saw the time drop a fair amount to ~4ms

<img width="553" alt="screen shot 2019-02-18 at 19 57 43" src="https://user-images.githubusercontent.com/25408167/52973868-7d8dfd80-33b7-11e9-83b2-c95088aea04e.png">

I've haven't got around to testing the functions for typing so if someone could look into that it would be awesome. I'm not actually sure they need changing 🤷‍♂️

I guess that update pattern could be factored out and reused as they all follow the same pattern but not sure it would actually help with readability.

@mdpye if you could take a look and give me a shout if you have feedback or changes?

---
EDIT:
It's worth mentioning that the `notTyping` action used to be unset/delete the key in the typing object but is now setting it to false. This is probably not ideal. And I'm still unsure if they actually need changing from what they were before anyway.